### PR TITLE
Add Leading 0 To Seconds

### DIFF
--- a/tomato.py
+++ b/tomato.py
@@ -59,7 +59,10 @@ def tomato(minutes, notify_msg):
             print('')
             break
 
-        countdown = '{}:{} ⏰'.format(int(left_seconds / 60), int(left_seconds % 60))
+        seconds_slot = int(left_seconds % 60)
+        seconds_str = str(seconds_slot) if seconds_slot >= 10 else '0{}'.format(seconds_slot)
+
+        countdown = '{}:{} ⏰'.format(int(left_seconds / 60), seconds_str)
         duration = min(minutes, 25)
         progressbar(diff_seconds, minutes * 60, duration, countdown)
         time.sleep(1)


### PR DESCRIPTION
Right now, there are no leading zeros in the clock's seconds slot:

![Screen Shot 2023-09-05 at 10 35 53 AM](https://github.com/coolcode/tomato-clock/assets/31993348/3c0d6015-f854-47ef-8848-4195ffa3befa)

This code change adds the leading zero:

![Screen Shot 2023-09-05 at 10 38 19 AM](https://github.com/coolcode/tomato-clock/assets/31993348/716fb194-38dd-4e08-84a2-d435f36c4800)
